### PR TITLE
Set the auth refreshToken value in iOS

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -1281,8 +1281,7 @@ BOOL static initialAuthState = true;
   userData[@"isAnonymous"] = @(user.isAnonymous);
   userData[@"emailVerified"] = @(user.isEmailVerified);
 
-  // native does not provide refresh tokens
-  userData[@"refreshToken"] = @"";
+  userData[@"refreshToken"] = user.refreshToken;
   return userData;
 }
 


### PR DESCRIPTION
## Description
This PR sets the refreshToken value which is used in Flutter. For some reason the upstream repo does not set this with a comment "native does not provide refresh tokens". However I can retrieve the refreshToken constantly during my testing. Maybe it's not possible in Android?

This refreshToken is then used to send to the iOS widget in [this PR](https://github.com/Insight-Timer/insight_timer_prod_flutter/pull/5927)